### PR TITLE
Fix bash vs sh differences

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
                 fonts-dejavu-core echoping curl lighttpd \
                 $(apt-get -s dist-upgrade|awk '/^Inst.*ecurity/ {print $2}') &&\
     apt-get clean && \
-    echo -e '+ EchoPingHttp\n\nbinary = /usr/bin/echoping\n' >> \
+    /bin/echo -e '+ EchoPingHttp\n\nbinary = /usr/bin/echoping\n' >> \
                 /etc/smokeping/config.d/Probes && \
-    echo -e '+ EchoPingHttps\n\nbinary = /usr/bin/echoping\n' >> \
+    /bin/echo -e '+ EchoPingHttps\n\nbinary = /usr/bin/echoping\n' >> \
                 /etc/smokeping/config.d/Probes && \
     sed -i '/server.errorlog/s|^|#|' /etc/lighttpd/lighttpd.conf && \
     sed -i '/server.document-root/s|/html||' /etc/lighttpd/lighttpd.conf && \
@@ -31,9 +31,9 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
                 /usr/share/smokeping/www/smokeping.fcgi && \
     lighttpd-enable-mod cgi && \
     lighttpd-enable-mod fastcgi && \
-    [[ -d /var/cache/smokeping ]] || mkdir -p /var/cache/smokeping && \
-    [[ -d /var/lib/smokeping ]] || mkdir -p /var/lib/smokeping && \
-    [[ -d /var/run/smokeping ]] || mkdir -p /var/run/smokeping && \
+    [ -d /var/cache/smokeping ] || mkdir -p /var/cache/smokeping && \
+    [ -d /var/lib/smokeping ] || mkdir -p /var/lib/smokeping && \
+    [ -d /var/run/smokeping ] || mkdir -p /var/run/smokeping && \
     chown -Rh smokeping:www-data /var/cache/smokeping /var/lib/smokeping \
                 /var/run/smokeping && \
     chmod -R g+ws /var/cache/smokeping /var/lib/smokeping /var/run/smokeping &&\
@@ -41,6 +41,7 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
     ln -s /usr/share/smokeping/www /var/www/smokeping && \
     ln -s /usr/lib/cgi-bin /var/www/ && \
     ln -s /usr/lib/cgi-bin/smokeping.cgi /var/www/smokeping/
+
 COPY smokeping.sh /usr/bin/
 
 VOLUME ["/etc/smokeping", "/etc/ssmtp", "/var/cache/smokeping", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
                 /etc/smokeping/config.d/Probes && \
     sed -i '/server.errorlog/s|^|#|' /etc/lighttpd/lighttpd.conf && \
     sed -i '/server.document-root/s|/html||' /etc/lighttpd/lighttpd.conf && \
-    sed -i '/#\s*"mod_rewrite"/s|#||' /etc/lighttpd/lighttpd.conf && \
-    /bin/echo -e 'url.rewrite-once            = ( "^/$" => "/smokeping/smokeping.cgi" )' >> \
+    /bin/echo -e 'url.redirect  = ("^/$" => "/smokeping/smokeping.cgi")' >> \
                 /etc/lighttpd/lighttpd.conf && \
     sed -i '/^#cgi\.assign/,$s/^#//; /"\.pl"/i \ \t".cgi"  => "/usr/bin/perl",'\
                 /etc/lighttpd/conf-available/10-cgi.conf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
                 /etc/smokeping/config.d/Probes && \
     sed -i '/server.errorlog/s|^|#|' /etc/lighttpd/lighttpd.conf && \
     sed -i '/server.document-root/s|/html||' /etc/lighttpd/lighttpd.conf && \
+    sed -i '/#\s*"mod_rewrite"/s|#||' /etc/lighttpd/lighttpd.conf && \
+    /bin/echo -e 'url.rewrite-once            = ( "^/$" => "/smokeping/smokeping.cgi" )' >> \
+                /etc/lighttpd/lighttpd.conf && \
     sed -i '/^#cgi\.assign/,$s/^#//; /"\.pl"/i \ \t".cgi"  => "/usr/bin/perl",'\
                 /etc/lighttpd/conf-available/10-cgi.conf && \
     sed -i -e '/CHILDREN/s/[0-9][0-9]*/16/' \

--- a/smokeping.sh
+++ b/smokeping.sh
@@ -92,10 +92,10 @@ title = '"$name"'\
 host = '"$target"'\
 '"$([[ "${alert:-""}" ]] && echo "alerts = someloss")"'
                 ' $file
-    grep -iq '^http:' <<< "$target" && sed -i '/^host = '"${target/*\//.*}"'$/a\
+    grep -iq '^http:' <<< "$target" && sed -i '/^host = '"${target/*\//.*}"'$/i\
 probe = EchoPingHttp
                 ' $file
-    grep -iq '^https:' <<<"$target" && sed -i '/^host = '"${target/*\//.*}"'$/a\
+    grep -iq '^https:' <<<"$target" && sed -i '/^host = '"${target/*\//.*}"'$/i\
 probe = EchoPingHttps
                 ' $file
 }


### PR DESCRIPTION
Thanks for the good work on this image - it saved me some time setting things up. 

When I first ran the image using your example command I got an error about the Probes config file when I accessed the smokeping url for the first time. This is fixed by using /bin/echo instead of echo as the /bin/sh builtin doesn't support -n.

When I built the image to try some changes I also go some errors output about the use of [[ as this is a bash builtin and not included in /bin/sh (which is dash on debian systems).

This PR fixes both of those issues. On my fork I also have changed the lighttpd config so that there is no need to type the smokeping.cgi url - a request for / is rewritten to /smokeping/smokeping.cgi. I will make a pull request for that if you're interested.