### PR TITLE
lighthttpd did not to start due to unescaped slash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
                 header=setenv.add-response-header && \
     sed -i '/server.errorlog/s|^|#|' $conf && \
     sed -i '/server.document-root/s|/html||' $conf && \
-    sed -i '/server.modules = (/a \t"mod_setenv",' $conf && \
+    sed -i '/server.modules = (/a \\t"mod_setenv",' $conf && \
     echo "\\n$header"' += ( "X-XSS-Protection" => "1; mode=block" )' >>$conf &&\
     echo "$header"' += ( "X-Content-Type-Options" => "nosniff" )' >>$conf && \
     echo "$header"' += ( "X-Robots-Tag" => "none" )' >>$conf&& \


### PR DESCRIPTION
An accidental literal `\t` in `lighthttpd.conf` prevented light-
httpd from starting. This commit escapes the \ properly as in [0].

[0]: https://github.com/nitr8/smokeping/commit/b0e529f0c098bb7c2844a6daea18b28cdf47bf6e